### PR TITLE
Add support for Pixi 0.53

### DIFF
--- a/src/pixi/projectManager.ts
+++ b/src/pixi/projectManager.ts
@@ -75,7 +75,7 @@ export class PixiPackageManager implements PackageManager, Disposable {
                 const project_path = path.dirname(manifest_path);
 
                 const stdout = await runPixi(
-                    ['list', '--no-lockfile-update', '--json', '--environment', environment.name],
+                    ['list', '--no-install', '--frozen', '--json', '--environment', environment.name],
                     {
                         cwd: project_path,
                     },

--- a/src/pixi/utils.ts
+++ b/src/pixi/utils.ts
@@ -102,9 +102,12 @@ export async function refreshPixi(project_path: string): Promise<PixiEnvironment
         const manifestPath = pixiInfo.project_info.manifest_path;
 
         for (const pixiEnv of pixiInfo.environments_info) {
-            const stdout = await runPixi(['list', '--no-lockfile-update', '--json', '--environment', pixiEnv.name], {
-                cwd: project_path,
-            });
+            const stdout = await runPixi(
+                ['list', '--no-install', '--frozen', '--json', '--environment', pixiEnv.name],
+                {
+                    cwd: project_path,
+                },
+            );
             const pixiPackages: PixiPackage[] = JSON.parse(stdout);
             const pythonPackage = pixiPackages.find((pkg) => pkg.name === 'python');
 


### PR DESCRIPTION
Pixi 0.53 removed `--no-lockfile-update` and replaced it with `--no-install --frozen`.