### PR TITLE
Add CLI options and use shell-hook for activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,18 @@
                     "default": "pixi",
                     "description": "Path to the Pixi executable. Leave empty to use auto-discovery.",
                     "scope": "machine-overridable"
+                },
+                "pixi-code.noInstall": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Add --no-install flag to pixi run and pixi shell-hook commands to skip installing dependencies.",
+                    "scope": "resource"
+                },
+                "pixi-code.frozen": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Add --frozen flag to pixi run and pixi shell-hook commands to skip re-locking.",
+                    "scope": "resource"
                 }
             }
         },


### PR DESCRIPTION
This PR adds configuration options for `--no-install` and `--frozen` flags and switches from `pixi shell` to `eval $(pixi shell-hook)` for environment activation.

Fixes #24 and fixes #28.

## Changes

### Configuration Options

Added two new configuration settings in `package.json`:

- **`pixi-code.noInstall`** (boolean, default: `false`): Adds the `--no-install` flag to `pixi run` and `pixi shell-hook` commands to skip installing dependencies
- **`pixi-code.frozen`** (boolean, default: `false`): Adds the `--frozen` flag to `pixi run` and `pixi shell-hook` commands to skip re-locking

These flags are applied to:
- `pixi run` commands when executing Python
- `pixi shell-hook` commands for environment activation

### Shell Activation Method

Changed the activation mechanism from using `pixi shell` to using `pixi shell-hook` with shell-specific evaluation commands.

**Previous approach:**
```typescript
activation: [
    {
        executable: pixi,
        args: ['shell', '--manifest-path', manifestPath, '-e', pixiEnv.name],
    },
]
```

**New approach:**
```typescript
shellActivation: createShellActivationCommands(pixi, manifestPath, envName, additionalFlags)
```

Where `createShellActivationCommands` generates shell-specific activation commands:

- **POSIX shells** (bash, zsh, sh, ksh, gitbash, wsl): `eval "$(pixi shell-hook ...)"`
- **Fish**: `eval (pixi shell-hook ...)`
- **PowerShell**: `Invoke-Expression (& pixi shell-hook ...)`
- **CMD**: Directly executes `pixi shell-hook ...`

This change addresses an issue with `pixi shell`: it creates a subprocess, which causes commands sent immediately after activation to get lost. This particularly affects VS Code's run and debug functionality, where Python files would fail to execute in the activated environment because the commands were sent before the subprocess was ready. Using `pixi shell-hook` with `eval` evaluates the activation commands directly in the current shell, ensuring all subsequent commands run in the properly activated environment.